### PR TITLE
The Chains that Bind Act of 2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,8 +594,6 @@ Where the Corps of Commanders determines a member is in violation of this sectio
 Once three warnings for violations of this section have been issued and it is violated again, a penalty up to dismissal may be imposed.
 
 ### §6. Breaking the chain that binds
-While Blizzard does maintain a Terms of Service agreement with all its players and a "Social Contract" that vaguely defines behaviors and actions that will prompt their attention when reported to them, this does not mean that they know the members of this guild better than its Commanders do or that they have the resources to properly adjudicate and prosecute violations of their policies.
-
 Should a member of this guild suffer any damages by another member of this guild that is simultaneously in violation of both another authority's policy and the Code of Honor and Valor, the guild asserts the prerogatives of:
 * treating of the matter first (i.e. the victim must report the matter to the Corps of Commanders before any other authority); and,
 * treating of the matter finally (i.e. the victim must secure permission from the Corps of Commanders to notify any other authority of any matters the Corps of Commanders has already considered, whether or not the offender was actioned by the guild in any way).
@@ -605,9 +603,8 @@ The privilege of arbitration and the appeal thereof shall survive dismissal subs
 No member of this guild shall challenge the guild's jurisdiction or venue as provided in this section before any other authority.
 
 The only exception to this regulation is a response to a violation of another authority's policy which:
-* represents an egregious danger to the victim which is incipient or so imminent that the guild cannot respond in an adequately timely manner;
-* represents a threat incommensurate to the guild's enforcement capability (e.g. a real-life, physical danger); or,
-* also constituted a violation of any provision of any federal law or regulation of the United States of America at the time the violation was committed.
+* represents an egregious danger to the victim which is incipient or so imminent that the guild cannot respond in an adequately timely manner; or,
+* represents a threat incommensurate to the guild's enforcement capability (e.g. a real-life, physical danger).
 
 The constraints in this section against notifying other authorities shall not extend to:
 * any office, bureau, or agency that constitutes a part of the United States government;

--- a/README.md
+++ b/README.md
@@ -596,15 +596,15 @@ Once three warnings for violations of this section have been issued and it is vi
 ### §6. Breaking the chain that binds
 While Blizzard does maintain a Terms of Service agreement with all its players and a "Social Contract" that vaguely defines behaviors and actions that will prompt their attention when reported to them, this does not mean that they know the members of this guild better than its Commanders do or that they have the resources to properly adjudicate and prosecute violations of their policies.
 
-Should a member of this guild suffer any damages by another member of this guild that is simultaneously in violation of both a Blizzard policy and the Code of Honor and Valor, the guild asserts the prerogatives of:
-* treating of the matter first (i.e. the victim must report the matter to the Corps of Commanders before Blizzard); and,
-* treating of the matter finally (i.e. the victim must secure permission from the Corps of Commanders to notify Blizzard of any matters the Corps of Commanders has already considered, whether or not the offender was actioned by the guild in any way).
+Should a member of this guild suffer any damages by another member of this guild that is simultaneously in violation of both another authority's policy and the Code of Honor and Valor, the guild asserts the prerogatives of:
+* treating of the matter first (i.e. the victim must report the matter to the Corps of Commanders before any other authority); and,
+* treating of the matter finally (i.e. the victim must secure permission from the Corps of Commanders to notify any other authority of any matters the Corps of Commanders has already considered, whether or not the offender was actioned by the guild in any way).
 
 The members of this guild by way of accepting an invite agree to submit all disputes arising under this section to arbitration by the Corps of Commanders, but shall have the privilege of appealing the decision of the same once per arbitration to the Council of Veterans.
 The privilege of arbitration and the appeal thereof shall survive dismissal subsequent to having been found guilty of violating this section and includes the possibility of the reversal of any punitive action taken by the guild which is reversible.
 No member of this guild shall challenge the guild's jurisdiction or venue as provided in this section before any other authority.
 
-The only exception to this regulation is a response to a violation of the Blizzard policy which:
+The only exception to this regulation is a response to a violation of another authority's policy which:
 * represents an egregious danger to the victim which is incipient or so imminent that the guild cannot respond in an adequately timely manner;
 * represents a threat incommensurate to the guild's enforcement capability (e.g. a real-life, physical danger); or,
 * also constituted a violation of any provision of any federal law or regulation of the United States of America at the time the violation was committed.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@
     - [§4c. Fraud](#4c-fraud)
     - [§4d. Impersonation](#4d-impersonation)
     - [§5. Political, religious, commercial, and promotional activities](#5-political-religious-commercial-and-promotional-activities)
-    - [§6. Ignoring a Commander's instructions](#6-ignoring-a-commanders-instructions)
+    - [§6. Breaking the chain that binds](#6-breaking-the-chain-that-binds)
+    - [§7. Ignoring a Commander's instructions](#7-ignoring-a-commanders-instructions)
 - [Title 5—Recruitment](#title-5recruitment)
   - [TITLE 5—Front Matter](#title-5front-matter)
 - [Title 6—Citizenship](#title-6citizenship)
@@ -592,7 +593,17 @@ Charitable projects on behalf of individuals in the guild (e.g. a funding initia
 Where the Corps of Commanders determines a member is in violation of this section, a warning will be issued.
 Once three warnings for violations of this section have been issued and it is violated again, a penalty up to dismissal may be imposed.
 
-### §6. Ignoring a Commander's instructions
+### §6. Breaking the chain that binds
+While Blizzard does maintain a Terms of Service agreement with all its players and a "Social Contract" that vaguely defines behaviors and actions that will prompt their attention when reported to them, this does not mean that they know the members of this guild better than its Commanders do or that they have the resources to properly adjudicate and prosecute violations of their policies.
+Should a member of this guild suffer any damages by another member of this guild that is simultaneously in violation of both a Blizzard policy and the Code of Honor and Valor, the guild asserts the privilege of treating of the matter before Blizzard is notified, i.e. the victim must speak with a Commander first.
+
+The only exception to this regulation is a response to a violation of the Blizzard policy which:
+  * represents an egregious danger to the victim which is incipient or so imminent that the guild cannot respond in an adequately timely manner; or,
+  * represents a threat incommensurate to the guild's enforcement capability (e.g. a real-life, physical danger).
+
+Where the Corps of Commanders determines that a member of the guild has violated this section the violation may result in immediate dismissal.
+
+### §7. Ignoring a Commander's instructions
 If a Commander gives an instruction based on a declaration of the Marshal or this code, failure to follow the instruction is a violation which may carry the penalty of immediate dismissal.
 
 # Title 5—Recruitment

--- a/README.md
+++ b/README.md
@@ -595,11 +595,24 @@ Once three warnings for violations of this section have been issued and it is vi
 
 ### §6. Breaking the chain that binds
 While Blizzard does maintain a Terms of Service agreement with all its players and a "Social Contract" that vaguely defines behaviors and actions that will prompt their attention when reported to them, this does not mean that they know the members of this guild better than its Commanders do or that they have the resources to properly adjudicate and prosecute violations of their policies.
-Should a member of this guild suffer any damages by another member of this guild that is simultaneously in violation of both a Blizzard policy and the Code of Honor and Valor, the guild asserts the privilege of treating of the matter before Blizzard is notified, i.e. the victim must speak with a Commander first.
+
+Should a member of this guild suffer any damages by another member of this guild that is simultaneously in violation of both a Blizzard policy and the Code of Honor and Valor, the guild asserts the prerogatives of:
+* treating of the matter first (i.e. the victim must report the matter to the Corps of Commanders before Blizzard); and,
+* treating of the matter finally (i.e. the victim must secure permission from the Corps of Commanders to notify Blizzard of any matters the Corps of Commanders has already considered, whether or not the offender was actioned by the guild in any way).
+
+The members of this guild by way of accepting an invite agree to submit all disputes arising under this section to arbitration by the Corps of Commanders, but shall have the privilege of appealing the decision of the same once per arbitration to the Council of Veterans.
+The privilege of arbitration and the appeal thereof shall survive dismissal subsequent to having been found guilty of violating this section and includes the possibility of the reversal of any punitive action taken by the guild which is reversible.
+No member of this guild shall challenge the guild's jurisdiction or venue as provided in this section before any other authority.
 
 The only exception to this regulation is a response to a violation of the Blizzard policy which:
-  * represents an egregious danger to the victim which is incipient or so imminent that the guild cannot respond in an adequately timely manner; or,
-  * represents a threat incommensurate to the guild's enforcement capability (e.g. a real-life, physical danger).
+* represents an egregious danger to the victim which is incipient or so imminent that the guild cannot respond in an adequately timely manner;
+* represents a threat incommensurate to the guild's enforcement capability (e.g. a real-life, physical danger); or,
+* also constituted a violation of any provision of any federal law or regulation of the United States of America at the time the violation was committed.
+
+The constraints in this section against notifying other authorities shall not extend to:
+* any office, bureau, or agency that constitutes a part of the United States government;
+* any office, bureau, or agency that constitutes a part of the government of a US State; or,
+* any law enforcement agency within the United States of America.
 
 Where the Corps of Commanders determines that a member of the guild has violated this section the violation may result in immediate dismissal.
 


### PR DESCRIPTION
*The Speaker of the House lays the following on the table under suspension for the purposes of public review, comment, and debate.*

6th House
H. R. 1

AN ACT to prevent the weaponization of Blizzard's new "Social Contract" requirement, or any other third party's policies regulating the interaction between guild members, by those that would seek to use the same to circumvent the principles of the Litany and to levy undue influence over their fellow guildmates.

This Act may be cited as the "Chains that Bind Act of 2022".

Be it enacted by the House of Representin' of the Guild of Honor and Valor assembled:

* 4 HVC §6 (Ignoring a Commander's instructions) is renumbered to 4 HVC §7.
* Section 6, entitled "Breaking the chain that binds", is added to Title 4, Chapter 1 of the guild code:
> Should a member of this guild suffer any damages by another member of this guild that is simultaneously in violation of both another authority's policy and the Code of Honor and Valor, the guild asserts the prerogatives of:
> * treating of the matter first (i.e. the victim must report the matter to the Corps of Commanders before any other authority); and,
> * treating of the matter finally (i.e. the victim must secure permission from the Corps of Commanders to notify any other authority of any matters the Corps of Commanders has already considered, whether or not the offender was actioned by the guild in any way).
> 
> The members of this guild by way of accepting an invite agree to submit all disputes arising under this section to arbitration by the Corps of Commanders, but shall have the privilege of appealing the decision of the same once per arbitration to the Council of Veterans. The privilege of arbitration and the appeal thereof shall survive dismissal subsequent to having been found guilty of violating this section and includes the possibility of the reversal of any punitive action taken by the guild which is reversible. No member of this guild shall challenge the guild's jurisdiction or venue as provided in this section before any other authority.
> 
> The only exception to this regulation is a response to a violation of another authority's policy which:
> * represents an egregious danger to the victim which is incipient or so imminent that the guild cannot respond in an adequately timely manner; or,
> * represents a threat incommensurate to the guild's enforcement capability (e.g. a real-life, physical danger).
> 
> The constraints in this section against notifying other authorities shall not extend to:
> * any office, bureau, or agency that constitutes a part of the United States government;
> * any office, bureau, or agency that constitutes a part of the government of a US State; or,
> * any law enforcement agency within the United States of America.
> 
> Where the Corps of Commanders determines that a member of the guild has violated this section the violation may result in immediate dismissal.