### PR TITLE
The Raid Supplies Act of 2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -931,7 +931,7 @@ Title 8 of the Honor and Valor code entitled "Banking" is codified into positive
 
 ### §1. Guild bank reserved items
 The following items that drop or are created in raids are reserved for the guild bank:
-* items that bind when equipped and that are not desired by the members of a raid for their personal use;
+* items that bind when equipped and that are not specifically earmarked by any members of a raid (e.g. soft reserved);
 * profession training items that do not bind when picked up; and
 * enchanting materials.
 


### PR DESCRIPTION
_The Speaker of the House lays the following on the table under suspension for the purposes of public review, comment, and debate._

6th House
H. R. 8

AN ACT to retain bind when equipped items not earmarked to specific raiders.

This Act may be cited as "The Raid Supplies Act of 2022".

Be it enacted by the House of Representin' of the Guild of Honor and Valor assembled:
* Section 1 of Title 8, entitled "Guild bank reserved items", is amended:
  * the first bullet item is struck, substituting: `items that bind when equipped and that are not specifically earmarked by any members of a raid (e.g. soft reserved)`