### PR TITLE
The Wrath of the Lich King Classic Phase Two Progression Act of 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,14 +749,18 @@ When a raid member's selections are required by the process in section 2 but the
     * Karazhan (resolved 9 Jun, 2021)
     * Gruul's Lair (resolved 22 Jun, 2021)
     * Hellfire Citadel (resolved 22 Jun, 2021)
-    * Naxxramas (Wrath of the Lich King, 25-man) (resolved 13 Aug, 2022)
-    * The Obsidian Sanctum (25-man) (resolved 13 Aug, 2022)
-    * The Eye of Eternity (25-man) (resolved 13 Aug, 2022)
-    * Vault of Archavon (25-man) (resolved 13 Aug, 2022)
+    * Naxxramas (Wrath of the Lich King, 25) (resolved 13 Aug, 2022)
+    * The Obsidian Sanctum (25) (resolved 13 Aug, 2022)
+    * The Eye of Eternity (25) (resolved 13 Aug, 2022)
+    * Vault of Archavon (25) (resolved 13 Aug, 2022)
+    * Ulduar (25) (resolved 17 Jan, 2023)
 3. The House has resolved that the following instances are no longer progression raids:
     * Karazhan (resolved 18 Jul, 2021)
     * Gruul's Lair (resolved 28 Apr, 2022)
     * Hellfire Citadel (resolved 28 Apr, 2022)
+    * Naxxramas (Wrath of the Lich King, 25) (resolved 17 Jan, 2023)
+    * The Obsidian Sanctum (25) (resolved 17 Jan, 2023)
+    * The Eye of Eternity (25) (resolved 17 Jan, 2023)
 
 ### §102. Required consumables
 All guild members shall be required to procure, to bring to, and to use the following consumable items as needed in each progression raid:

--- a/README.md
+++ b/README.md
@@ -753,14 +753,14 @@ When a raid member's selections are required by the process in section 2 but the
     * The Obsidian Sanctum (25) (resolved 13 Aug, 2022)
     * The Eye of Eternity (25) (resolved 13 Aug, 2022)
     * Vault of Archavon (25) (resolved 13 Aug, 2022)
-    * Ulduar (25) (resolved 17 Jan, 2023)
+    * Ulduar (25) (resolved 15 Jan, 2023)
 3. The House has resolved that the following instances are no longer progression raids:
     * Karazhan (resolved 18 Jul, 2021)
     * Gruul's Lair (resolved 28 Apr, 2022)
     * Hellfire Citadel (resolved 28 Apr, 2022)
-    * Naxxramas (Wrath of the Lich King, 25) (resolved 17 Jan, 2023)
-    * The Obsidian Sanctum (25) (resolved 17 Jan, 2023)
-    * The Eye of Eternity (25) (resolved 17 Jan, 2023)
+    * Naxxramas (Wrath of the Lich King, 25) (resolved 15 Jan, 2023)
+    * The Obsidian Sanctum (25) (resolved 15 Jan, 2023)
+    * The Eye of Eternity (25) (resolved 15 Jan, 2023)
 
 ### §102. Required consumables
 All guild members shall be required to procure, to bring to, and to use the following consumable items as needed in each progression raid:


### PR DESCRIPTION
_The Speaker of the House lays the following on the table under suspension for the purposes of public review, comment, and debate._

6th House
H. R. 9

AN ACT to amend Title 7 in preparation for the raiding content in the second phase of Wrath of the Lich King Classic, and for other purposes.

This Act may be cited as "The Wrath of the Lich King Classic Phase Two Progression Act of 2023".

Be it enacted by the House of Representin' of the Guild of Honor and Valor assembled:
* Section 101 of Title 7, is amended:
  * striking all gendered language;
  * adding `Naxxramas (Wrath of the Lich King, 25) (resolved 15 Jan, 2023)` to the bullet list of subsection 3;
  * adding `The Obsidian Sanctum (25) (resolved 15 Jan, 2023)` to the bullet list of subsection 3;
  * adding `The Eye of Eternity (25) (resolved 15 Jan, 2023)` to the bullet list of subsection 3; and,
  * adding `Ulduar (25) (resolved 15 Jan, 2023)` to the bullet list of subsection 2.