### PR TITLE
The Hardcore Citizenship Act of 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@
   - [TITLE 6—Front Matter](#title-6front-matter)
   - [CHAPTER 1—PATHS TO CITIZENSHIP](#chapter-1paths-to-citizenship)
     - [§1. Raiding](#1-raiding)
+    - [§2. Remaining Mortal at Maximum Level in Hardcore](#2-remaining-mortal-at-maximum-level-in-hardcore)
   - [CHAPTER 2—LOSS OF CITIZENSHIP](#chapter-2loss-of-citizenship)
     - [§101. Renunciation of Citizenship](#101-renunciation-of-citizenship)
     - [§102. Loss of Citizenship](#102-loss-of-citizenship)
@@ -705,6 +706,11 @@ Title 6 of the Honor and Valor code entitled "Citizenship" is codified into posi
 
 ### §1. Raiding
 Those having attended two lockouts worth of progression raiding will be granted citizenship and awarded the rank of Citizen if they do not already possess a higher rank.
+
+### §2. Remaining Mortal at Maximum Level in Hardcore
+The Citizen rank will be granted to those either having:
+* completed the Hardcore Community Challenge, verified their run, and chosen to remain mortal; or,
+* attained maximum level on a Blizzard Hardcore realm.
 
 ## CHAPTER 2—LOSS OF CITIZENSHIP
 


### PR DESCRIPTION
_The Speaker of the House lays the following on the table under suspension for the purposes of public review, comment, and debate._

6th House
H. R. 11

AN ACT to amend Title 6 to grant the rank of Citizen to members of the guild who have made significant achievements in Hardcore.

This Act may be cited as "The Hardcore Citizenship Act of 2023".

Be it enacted by the House of Representin' of the Guild of Honor and Valor assembled:

* Section 2, entitled "Remaining Mortal at Maximum Level in Hardcore", is added to Title 6 of the guild code:
> The Citizen rank will be granted to those either having:
> * completed the Hardcore Community Challenge, verified their run, and chosen to remain mortal; or,
> * attained maximum level on a Blizzard Hardcore realm.